### PR TITLE
tests: move setup to main_test.go

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -5,8 +5,11 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/rogpeppe/go-internal/testscript"
@@ -21,12 +24,34 @@ func TestMain(m *testing.M) {
 var update = flag.Bool("u", false, "update testscript output files")
 
 func TestScripts(t *testing.T) {
+	if _, err := exec.LookPath("docker"); err != nil {
+		t.Skip("docker is required to run dockexec tests")
+	}
+
 	t.Parallel()
 
 	testscript.Run(t, testscript.Params{
 		Dir: filepath.Join("testdata", "scripts"),
 		Setup: func(env *testscript.Env) error {
-			env.Vars = append(env.Vars, "TESTBIN="+os.Args[0])
+			bindir := filepath.Join(env.WorkDir, ".bin")
+			if err := os.Mkdir(bindir, 0777); err != nil {
+				return err
+			}
+			binfile := filepath.Join(bindir, "dockexec")
+			if runtime.GOOS == "windows" {
+				binfile += ".exe"
+			}
+			if err := os.Symlink(os.Args[0], binfile); err != nil {
+				return err
+			}
+			env.Vars = append(env.Vars, fmt.Sprintf("PATH=%s%c%s", bindir, filepath.ListSeparator, os.Getenv("PATH")))
+			env.Vars = append(env.Vars, "TESTSCRIPT_COMMAND=dockexec")
+
+			// GitHub Actions doesn't define %LocalAppData% on
+			// Windows, which breaks $GOCACHE. Set it ourselves.
+			if runtime.GOOS == "windows" {
+				env.Vars = append(env.Vars, fmt.Sprintf(`LOCALAPPDATA=%s\appdata`, env.WorkDir))
+			}
 
 			for _, name := range [...]string{
 				"HOME",

--- a/testdata/scripts/basic.txt
+++ b/testdata/scripts/basic.txt
@@ -1,18 +1,4 @@
-[!exec:go] skip
-[!exec:docker] skip
-[!symlink] skip
-
-# We want to use the current dockexec, not whichever happens to be globally
-# installed. Use the test binary with TESTSCRIPT_COMMAND, which we know will
-# correctly run dockexec thanks to go-internal/testscript.
-mkdir .bin
-symlink .bin/dockexec$exe -> $TESTBIN
-env PATH=.bin${:}$PATH
-env TESTSCRIPT_COMMAND=dockexec
-
-# GitHub Actions doesn't export %LocalAppData% yet, so do it here to ensure the
-# test passes.
-[windows] env LOCALAPPDATA=$WORK\appdata
+# Basic test cases for dockexec
 
 # Check that we succeed without -exec.
 exec go test


### PR DESCRIPTION
In preparation for more testscripts, move common setup to main_test.go
so that other scripts can leverage it.