### PR TITLE
flags: define the -compose flag to allow use of docker-compose

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,7 @@ name: Test
 jobs:
   test:
     strategy:
+      fail-fast: false
       matrix:
         go-version: [1.13.x, 1.14.x]
         platform: [ubuntu-latest, macos-latest, windows-latest]

--- a/testdata/scripts/compose.txt
+++ b/testdata/scripts/compose.txt
@@ -1,0 +1,27 @@
+# Test that the -prog flag works as expected
+
+[!exec:docker-compose] skip 'Requires docker-compose'
+[windows] skip 'TODO: support windows-native images in --volume flags'
+[!windows] env IMAGE=busybox:1.31.1-musl
+
+go test -v -exec 'dockexec -compose eg'
+stdout Hello
+! stderr .+
+
+-- go.mod --
+module mod.com/blah
+
+-- main_test.go --
+package main
+
+import "testing"
+
+func TestThis(t *testing.T) {
+	println("Hello")
+}
+-- docker-compose.yml --
+version: '3.2'
+
+services:
+  eg:
+    image: $IMAGE


### PR DESCRIPTION
 By default, dockexec uses the docker command to run commands within a
    container. However, docker-compose exposes a compatible run command (and
    flags). Providing the -compose flag means we can use dockexec to in the
    context of a docker-compose configuration.
