### PR TITLE
main: handle dockexec being called with package that is module root

### DIFF
--- a/main.go
+++ b/main.go
@@ -88,9 +88,10 @@ func mainerr() error {
 	//
 	//   [docker flags] pkg.test [test flags]
 	//
-	// For now, parse this by looking for the first argument that doesn't
-	// start with "-", and which looks like a Go binary. If this isn't
-	// enough in the long run, we can start parsing docker flags instead.
+	// For now, parse this by looking for the first argument that doesn't start
+	// with "-", and which looks like a Go binary (remembering that main
+	// packages at the module root might contain dots, e.g. foo.com). If this
+	// isn't enough in the long run, we can start parsing docker flags instead.
 	//
 	// As of today, the binary can look like (possibly with an ".exe" suffix):
 	//
@@ -99,7 +100,7 @@ func mainerr() error {
 	var dockerFlags []string
 	var binary string
 	var testFlags []string
-	rxBinary := regexp.MustCompile(`\.test(\.exe)?$|/exe/[a-zA-Z0-9_]+(\.exe)?$`)
+	rxBinary := regexp.MustCompile(`\.test(\.exe)?$|/exe/[a-zA-Z0-9_]+(\.[a-zA-Z0-9_]+)?(\.exe)?$`)
 	for i, arg := range args {
 		if !strings.HasPrefix(arg, "-") && rxBinary.MatchString(arg) {
 			dockerFlags = args[:i]

--- a/testdata/scripts/run_module_root.txt
+++ b/testdata/scripts/run_module_root.txt
@@ -1,0 +1,21 @@
+# Test that dockexec works from a module root that is a domain only
+
+[!windows] env IMAGE=busybox:1.31.1-musl
+[windows] skip 'TODO: support windows-native images in --volume flags'
+
+exec go run -exec='dockexec '$IMAGE .
+stdout 'Hello'
+
+-- go.mod --
+module domain.totallyfaketld
+
+-- main.go --
+package main
+
+import (
+	"fmt"
+)
+
+func main() {
+	fmt.Println("Hello")
+}


### PR DESCRIPTION
Given a module called foo.com, and a package at the root of that module,
the result binary name is foo.com. Improve the regex that is used to
find the Go binary in the arguments passed to dockexec to support such
cases. Add a test case to cover it.